### PR TITLE
fix: add timestamps to tables

### DIFF
--- a/database/migrations/20211228155256_add-timestamps.js
+++ b/database/migrations/20211228155256_add-timestamps.js
@@ -1,0 +1,34 @@
+const env = require('../database-env')
+const schemaName = env.PGSCHEMA
+
+exports.up = function(knex) {
+  return knex.schema.withSchema(schemaName)
+    .table('permissions', t => t.timestamps(true, true))
+    .table('rolepermissions', t => t.timestamps(true, true))
+    .table('clients', t => t.timestamps(true, true))
+    .table('personaroles', t => t.timestamps(true, true))
+    .table('personapermissions', t => t.timestamps(true, true))
+    .table('personas', t => t.timestamps(true, true))
+    .table('tenantclients', t => t.timestamps(true, true))
+    .table('tenants', t => t.timestamps(true, true))
+    .table('keys', t => t.timestamps(true, true))
+    .table('roles', t => {
+      t.timestamps(true, true)
+      // remove duplicate unique index
+      t.dropUnique(['name', 'clientkey'], 'permissions_name_clientkey_uq')
+    })
+}
+
+exports.down = function(knex) {
+  return knex.schema.withSchema(schemaName)
+    .table('permissions', t => t.dropTimestamps())
+    .table('rolepermissions', t => t.dropTimestamps())
+    .table('clients', t => t.dropTimestamps())
+    .table('personaroles', t => t.dropTimestamps())
+    .table('personapermissions', t => t.dropTimestamps())
+    .table('personas', t => t.dropTimestamps())
+    .table('tenantclients', t => t.dropTimestamps())
+    .table('tenants', t => t.dropTimestamps())
+    .table('keys', t => t.dropTimestamps())
+    .table('roles', t => t.dropTimestamps()) // no-op for dropping duplicate index
+}


### PR DESCRIPTION
# Overview

Add `created_at` and `modified_at` columns to the currently used database tables. They will default to current timestamp on insert.
Remove duplicate unique constraint on the `roles` table.

## Your PR Checklist 🚨

❤️ Please review the [guidelines for contributing](../docs/CONTRIBUTING.md) to this repository. Our goal is to merge PRs fast 💨 .

- [x] Check your code additions will fail neither code linting checks nor unit tests.
- [x] Additional units tests have been added to prove code updates work and fixes are effective
- [x] Additional documentation has been added (if appropriate)
- [x] Update Assignee field to yourself

## Issue Reference

<!-- Add a reference to the Issue number -->
Closes NA

## Open Questions or Items to Callout

1. Are we ok with using knexjs functions for quality of life coding when managing migrations?
