### PR TITLE
fix: fix self/roles api

### DIFF
--- a/server/test/endpoint_self_roles.test.js
+++ b/server/test/endpoint_self_roles.test.js
@@ -1,0 +1,46 @@
+const { describe, it, before } = require('mocha')
+const fetch = require('node-fetch')
+const assert = require('assert')
+
+const { getTestUser1IdPToken } = require('./lib/tokens')
+const { getServerUrl } = require('./lib/urls')
+
+describe('Get Self Roles', () => {
+  let userAccessToken = ''
+  const url = `${getServerUrl()}`
+
+  before(async function () {
+    // GET IDENTITY-PROVIDER TOKEN
+    userAccessToken = await getTestUser1IdPToken()
+  })
+
+  it('should return roles for given client_id', async function () {
+    const requestHeaders = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${userAccessToken}`,
+      client_id: 'test-client1',
+    }
+    const response = await fetch(`${url}/self/roles`, { method: 'GET', headers: requestHeaders })
+    let actualRoles = (await response.json()).data
+
+    // verify the role names are expected
+    const actualNames = actualRoles.map(r => r.name)
+    const expectedNames = ['test-client1:test-role1', 'test-client1:test-role2']
+    assert.strictEqual(JSON.stringify(actualNames), JSON.stringify(expectedNames), `Expected roles: "${expectedNames}" Actual roles: "${actualNames}"`)
+  })
+
+  it('should return roles for any client', async function () {
+    const requestHeaders = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${userAccessToken}`,
+      client_id: '*',
+    }
+    const response = await fetch(`${url}/self/roles`, { method: 'GET', headers: requestHeaders })
+    let actualRoles = (await response.json()).data
+
+    // verify the role names are expected
+    const actualNames = actualRoles.map(r => r.name)
+    const expectedNames = ['test-client1:test-role1', 'test-client1:test-role2', 'test-client2:test-role1', 'test-client3:test-role1']
+    assert.strictEqual(JSON.stringify(actualNames), JSON.stringify(expectedNames), `Expected roles: "${expectedNames}" Actual roles: "${actualNames}"`)
+  })
+})


### PR DESCRIPTION
# Overview

Corrects bug in `/self/roles` API to return the correct response after updates were made related to admin APIs for roles. 
Added test coverage for this API

## Your PR Checklist 🚨

❤️ Please review the [guidelines for contributing](../docs/CONTRIBUTING.md) to this repository. Our goal is to merge PRs fast 💨 .

- [x] Check your code additions will fail neither code linting checks nor unit tests.
- [x] Additional units tests have been added to prove code updates work and fixes are effective
- [x] Additional documentation has been added (if appropriate)
- [x] Update Assignee field to yourself

## Issue Reference

<!-- Add a reference to the Issue number -->
Closes #24 

## Open Questions or Items to Callout

1. The response returns `clientkey` (db auto-increment pk field), but does not return `client_id` (unique string value), should this be added?
