### PR TITLE
QUICKSTART.md: Correct IDP token script invocation

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -37,7 +37,7 @@ The Usher ships with a mock identity provider that simulates Auth0's API endpoin
 Let's keep a copy of an access token using jq to grab it from the JSON output:
 
 ```sh
-export IDP_TOKEN=`./server/scripts/get_jwt_for_test_tenant.sh | jq --raw-output .access_token`
+export IDP_TOKEN=`./server/scripts/get_idp_token_from_mockserver.sh | jq --raw-output .access_token`
 ```
 
 Now let's use the IdP token to get an access token from The Usher:


### PR DESCRIPTION

# Overview

The quickstart referred to an old non-existing script for getting the identity provider token; this change updates to use the mock ID server which was made for this purpose.

## Your PR Checklist 🚨

❤️ Please review the [guidelines for contributing](../docs/CONTRIBUTING.md) to this repository. Our goal is to merge PRs fast 💨 .

- [X] Check your code additions will fail neither code linting checks nor unit tests.
- [ ] Additional units tests have been added to prove code updates work and fixes are effective
- [ ] Additional documentation has been added (if appropriate)
- [ ] Update Assignee field to yourself
