### PR TITLE
explain mock identity provider behavior, update script

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -18,7 +18,15 @@ Done. 🚀 This will launch three containers: The Usher server, its database (se
 
 The next step is to get a token from an identity provider to use with The Usher.  For short, we refer to this as an IdP Token.
 
-The Usher ships with a mock identity provider that simulates Auth0's API endpoint (`/oauth/token`) and issues IdP tokens for a few hardcoded users with username and password authentication (these users are the ones in the test seed data for The Usher's database). We have provided a script to obtain a token from the mock identity server:
+The Usher ships with a mock identity provider that simulates Auth0's API endpoint (`/oauth/token`) and issues IdP tokens for a few hardcoded users with username and password authentication (these users are the ones in the test seed data for The Usher's database).
+
+The mock identity provider is fairly simple, and returns tokens with the `iss` (issuer) claim set based on the hostname you use when accessing it.  For the purposes of this quickstart, given the identities in the test database, you should ensure the mock identity provider is accessible via the hostname `idp.dmgt.com.mock.localhost`.  Depending on your operating system, `docker compose` may create an alias (check this by running `ping idp.dmgt.com.mock.localhost`).  However, if it does not, then manually add to `/etc/hosts` an entry like:
+
+```
+127.0.0.1 idp.dmgt.com.mock.localhost
+```
+
+Then, call the following script to obtain a token from the mock identity server:
 
 ```sh
 ./server/scripts/get_idp_token_from_mockserver.sh | json_pp

--- a/server/scripts/get_idp_token_from_mockserver.sh
+++ b/server/scripts/get_idp_token_from_mockserver.sh
@@ -7,5 +7,4 @@ curl -X POST -H "Content-Type: application/json" -d '{
       "password": "password12345!",
        "grant_type": "http://auth0.com/oauth/grant-type/password-realm",
         "realm": "Username-Password-Authentication"
-      }' "http://localhost:3002/oauth/token"
-      # }' "http://idp.dmgt.com.mock.localhost:3002/oauth/token"
+      }' "http://idp.dmgt.com.mock.localhost:3002/oauth/token"


### PR DESCRIPTION
# Overview

This PR makes improvements to the Quickstart and to a related script to ensure that everything works for a new user interested in test-driving the Usher.

The current problem is that the `server/scripts/get_idp_token_from_mockserver.sh` script accesses the mock identity provider via host `localhost:3002`.  Although an identity token is returned, the following steps won't work because (1) that host isn't whitelisted in The Usher's environment sample file, and (2) the identities in the test PostgreSQL database are not identified as authenticated using that host.


# Summary of Proposed Changes

<!-- Write a brief overview for the PR, and what was addressed -->

* The `get_idp_token_from_mockserver.sh` script was fixed to invoke the identity provider using `idp.dmgt.com.mock.localhost:3002` as the host, which is a whitelisted host
* The Quickstart was updated to include a note to the effect that if the hostname `idp.dmgt.com.mock.localhost` is not recognized on the local network, it should be added to `/etc/hosts`.

## Your PR Checklist 🚨

❤️ Please review the [guidelines for contributing](../docs/CONTRIBUTING.md) to this repository. Our goal is to merge PRs fast 💨 .

- [X] Check your code additions will fail neither code linting checks nor unit tests.
- [ ] Additional units tests have been added to prove code updates work and fixes are effective
- [X] Additional documentation has been added (if appropriate)
- [ ] Update Assignee field to yourself

## Open Questions or Items to Callout

N/A

