### PR TITLE
Topic/k1ch/ internal caching for GET:/jwks.json

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dmgt-tech/the-usher-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dmgt-tech/the-usher-server",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
@@ -22,6 +22,7 @@
         "js-yaml": "4.1.0",
         "jwks-rsa": "3.1.0",
         "moment": "2.30.1",
+        "node-cache": "5.1.2",
         "oas-tools": "2.2.2",
         "pem-jwk": "2.0.0",
         "serverless-http": "3.1.0",
@@ -3114,6 +3115,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dmgt-tech/the-usher-server",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Usher Authorization Server",
   "engines": {
     "node": ">=18"
@@ -32,6 +32,7 @@
     "js-yaml": "4.1.0",
     "jwks-rsa": "3.1.0",
     "moment": "2.30.1",
+    "node-cache": "5.1.2",
     "oas-tools": "2.2.2",
     "pem-jwk": "2.0.0",
     "serverless-http": "3.1.0",

--- a/server/src/api_endpoints/endpoint_jwksjson.js
+++ b/server/src/api_endpoints/endpoint_jwksjson.js
@@ -1,16 +1,28 @@
 const keystore = require('database/layer/db-keys')
 const { pem2jwk } = require('pem-jwk')
 const createError = require('http-errors')
+const NodeCache = require('node-cache')
 
+const myCache = new NodeCache({ stdTTL: 60, checkperiod: 30 })
 const getJwks = async (req, res) => {
   try {
-    const keyPairs = await keystore.selectAllKeys()
-    const publicKeys = keyPairs?.map(keyPair => {
-      const item = pem2jwk(keyPair.public_key)
-      item.kid = keyPair.kid
-      return item
-    })
-    res.status(200).send({ keys: publicKeys })
+    const cacheKeyName = 'usher-jwks'
+    let response = myCache.get(cacheKeyName)
+
+    if (response) {
+      res.set('x-cache', 'Hit from Usher')
+    } else {
+      const keyPairs = await keystore.selectAllKeys()
+      const publicKeys = keyPairs?.map(keyPair => {
+        const item = pem2jwk(keyPair.public_key)
+        item.kid = keyPair.kid
+        return item
+      })
+      response = { keys: publicKeys }
+      myCache.set(cacheKeyName, response)
+    }
+
+    res.status(200).send(response)
   } catch ({ httpStatusCode = 500, message }) {
     return next(createError(httpStatusCode, { message }))
   }

--- a/server/test/endpoint_jwks.test.js
+++ b/server/test/endpoint_jwks.test.js
@@ -6,12 +6,19 @@ const { getServerUrl } = require('./lib/urls')
 
 describe('Get JWKS', () => {
   const url = `${getServerUrl()}/.well-known/jwks.json`
+  const fetchJWKS = () => fetch(url, { method: 'GET', headers: { 'Content-Type': 'application/json' } });
 
-  it('should return a JWKS containing a list of keys', async function () {
-    const response = await fetch(url, { method: 'GET', headers: { 'Content-Type': 'application/json' } })
-    assert.strictEqual(response.status, 200)
+  it('should return a JWKS containing a list of keys', async () => {
+    const response = await fetchJWKS()
+    assert.equal(response.status, 200)
     const jwks = await response.json()
     assert('keys' in jwks, 'There should be a keys element in the object.')
     assert(jwks.keys.length > 0, 'There should be at least one key in the keys array')
+  })
+
+  it('should return a JWKS from internal cache', async () => {
+    const response = await fetchJWKS()
+    assert.equal(response.status, 200)
+    assert.equal(response.headers.get('x-cache'), 'Hit from Usher')
   })
 })


### PR DESCRIPTION
# Overview
Enables internal caching for `GET:/jwks.json` to limit the number of DB connection within 60 seconds.

- [feat: topic/k1ch/ internal caching for GET:/jwks.json](https://github.com/DMGT-TECH/the-usher-server/commit/1f1a937a5cba49cbfc1f6a0277edeeaf44cbaf62)

<!-- Write a brief overview for the PR, and what was addressed -->

## Your PR Checklist 🚨

❤️ Please review the [guidelines for contributing](../docs/CONTRIBUTING.md) to this repository. Our goal is to merge PRs fast 💨 .

- [x] Check your code additions will fail neither code linting checks nor unit tests.
- [x] Additional units tests have been added to prove code updates work and fixes are effective
- [ ] Additional documentation has been added (if appropriate)
- [x] Update Assignee field to yourself

## Issue Reference

<!-- Add a reference to the Issue number -->
Closes #

## Open Questions or Items to Callout

<!-- Use this area to document any specific questions or areas of concern for the Reviewers -->
